### PR TITLE
[llvm][llc] Remove unneeded Arg for GetOutputStream

### DIFF
--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -255,8 +255,7 @@ static int compileModule(char **, LLVMContext &);
   llvm_unreachable("reportError() should not return");
 }
 
-static std::unique_ptr<ToolOutputFile> GetOutputStream(const char *TargetName,
-                                                       Triple::OSType OS,
+static std::unique_ptr<ToolOutputFile> GetOutputStream(Triple::OSType OS,
                                                        const char *ProgName) {
   // If we don't yet have an output filename, make one.
   if (OutputFilename.empty()) {
@@ -611,7 +610,7 @@ static int compileModule(char **argv, LLVMContext &Context) {
 
   // Figure out where we are going to send the output.
   std::unique_ptr<ToolOutputFile> Out =
-      GetOutputStream(TheTarget->getName(), TheTriple.getOS(), argv[0]);
+      GetOutputStream(TheTriple.getOS(), argv[0]);
   if (!Out) return 1;
 
   // Ensure the filename is passed down to CodeViewDebug.


### PR DESCRIPTION
The "TargetName" is not used in the GetOutputStream() function, so remove it and its respective argument.